### PR TITLE
Feature request: split and extend the bot API for general usage, and add some examples

### DIFF
--- a/examples/bot_script.py
+++ b/examples/bot_script.py
@@ -1,0 +1,76 @@
+import signal
+import asyncio
+import contextlib
+from weakref import ref
+
+from karuha.bot import Bot, State, get_stream
+from karuha.config import load_config
+from karuha.event.bot import BotInitEvent
+from karuha.exception import KaruhaBotError
+from karuha.runner import _handle_sigterm
+
+async def run_bot_loop(bot):
+    bot._loop_task_ref = ref(asyncio.current_task())
+    while bot.state == State.running:
+        bot.logger.info(f"starting the bot {bot.name}")
+        async with bot._run_context(bot.server) as channel:
+            stream = get_stream(channel)  # type: ignore
+            msg_gen = bot._message_generator()
+            client = stream(msg_gen)
+            await bot._loop(client)
+
+async def run_hello(bot):
+    tid, params = await bot.hello()
+    print(tid, params)
+
+async def run_subscribe(bot):
+    tid, params = await bot.subscribe("topic_test")
+    print(tid, params)
+
+async def run_create_account(bot: Bot, name: str):
+    try:
+        tid, params = await bot.account(
+            scheme = 'basic',
+            secret = f'{name}:test123',
+            fn = 'Test User',
+            tags = 'test,test-user',
+            auth = 'JRWPA',
+            anon = 'JW',
+            cred = 'email:test@example.com',
+            do_login=True
+        )
+        print(tid, params)
+    except KaruhaBotError as e:
+        print(e)
+
+async def run_bot_prepare(bot):
+    print("start run_bot_prepare")
+    bot._prepare_loop_task()
+
+async def run_bot_init(bot):
+    Bot.initialize_event_callback = BotInitEvent.new_and_wait
+    await bot.initialize_event_callback(bot)
+
+async def main():
+    config = load_config()
+    _loop = asyncio.get_running_loop()
+    _loop.set_debug(enabled=True)
+    with contextlib.suppress(NotImplementedError):
+        _loop.add_signal_handler(signal.SIGTERM, _handle_sigterm)
+
+    for i in range(153, 160):
+        print("i:", i)
+        # create a bot without login
+        bot = Bot.from_config(config.bots[0], config)
+        await _loop.create_task(run_bot_prepare(bot))
+        print("BOT prepare finished")
+        task_loop = _loop.create_task(run_bot_loop(bot))
+        await _loop.create_task(run_bot_init(bot))
+        await _loop.create_task(run_create_account(bot, f'test{i}'))
+        bot.cancel()
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except (KeyboardInterrupt, asyncio.CancelledError):  # pragma: no cover
+        pass

--- a/karuha/config.py
+++ b/karuha/config.py
@@ -20,8 +20,8 @@ class Server(BaseModel):
 
 class Bot(BaseModel):
     name: str = "chatbot"
-    schema_: Literal["basic", "token", "cookie"] = Field(alias="schema")
-    secret: str
+    schema_: Optional[Literal["basic", "token", "cookie"]] = Field(default=None, alias="schema")
+    secret: Optional[str] = None
     auto_subscribe_new_user: bool = False
 
 

--- a/karuha/event/bot.py
+++ b/karuha/event/bot.py
@@ -44,7 +44,8 @@ class BotInitEvent(BotEvent):
             self.bot.logger.error("failed to connect to server, restarting")
             self.bot.restart()
             return
-        
+        if not bot._needs_login:
+            return
         retry = bot.server.retry if bot.server is not None else 0
         for i in range(retry):
             try:


### PR DESCRIPTION
Hello, 

Thanks for your great work again. I want to do automatic jobs (e.g. creating accounts) on Tinode, and I have noticed that you provide a lower-level API `bot`. However, these APIs are specially designed for the chatbot and not ready for users. I think it would be a good idea to refactor the `bot` API to a separate and general python library to interact with Tinode server. After that, we can extend this library's usage such as rewrite [tn-cli](https://github.com/tinode/chat/tree/master/tn-cli).

This PR is an example of using `bot` to create accounts, and several necessary modifications to the bot to implement it. It is not ready to be merged.

What do you think about this idea?